### PR TITLE
Enable importing express app

### DIFF
--- a/lib/restbus.js
+++ b/lib/restbus.js
@@ -132,4 +132,6 @@ restbus.isListening = function() {
   return listening;
 };
 
+restbus.app = app;
+
 module.exports = restbus;


### PR DESCRIPTION
Added express `app` to the exported module in `restbus.js`. This enables mounting restbus as a [sub-application](https://gist.github.com/focusaurus/5779340) in another express application. 

```
const restbusApp = require('restbus').app
const app = require('express')();

app.use(_some-custom-middleware_);
app.use('/', restbusApp);

app.listen(...)
```

This also enables setting up custom express middleware, for example caching using redis for repeated requests within a certain interval. 